### PR TITLE
Update buttonmap/topology for original Atari controllers

### DIFF
--- a/game.libretro.atari800/addon.xml.in
+++ b/game.libretro.atari800/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="game.libretro.atari800"
 		name="Atari - 5200 (Atari800)"
-		version="3.1.0.33"
+		version="3.1.0.34"
 		provider-name="Petr Stehlik">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>

--- a/game.libretro.atari800/addon.xml.in
+++ b/game.libretro.atari800/addon.xml.in
@@ -5,7 +5,8 @@
 		provider-name="Petr Stehlik">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
-		<import addon="game.controller.default" version="1.0.0"/>
+		<import addon="game.controller.atari.800" version="1.0.0"/>
+		<import addon="game.controller.atari.5200" version="1.0.32"/>
 		<import addon="game.controller.keyboard" version="1.0.0"/>
 		<import addon="game.controller.mouse" version="1.0.0"/>
 	</requires>

--- a/game.libretro.atari800/resources/buttonmap.xml
+++ b/game.libretro.atari800/resources/buttonmap.xml
@@ -1,22 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-    <controller id="game.controller.default" type="RETRO_DEVICE_JOYPAD" subclass="1">
+    <controller id="game.controller.atari.800" type="RETRO_DEVICE_JOYPAD" subclass="1">
+        <feature name="fire1" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+        <feature name="fire2" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
         <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+        <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
         <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
         <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
-        <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
-        <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
-        <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
-        <feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
-        <feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
         <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
-        <feature name="back" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
-        <feature name="leftthumb" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
-        <feature name="rightthumb" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
-        <feature name="leftbumper" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
-        <feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
-        <feature name="lefttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
-        <feature name="righttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
+        <feature name="select" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+        <feature name="option" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
+        <feature name="space" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
+        <feature name="return" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
+        <feature name="escape" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
+        <feature name="menu" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+        <feature name="help" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
+        <feature name="togglevkbd" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
+    </controller>
+    <controller id="game.controller.atari.5200" type="RETRO_DEVICE_JOYPAD" subclass="2">
+        <feature name="fire1" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+        <feature name="fire2" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+        <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
+        <feature name="pause" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+        <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+        <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+        <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+        <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+        <feature name="num1" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+        <feature name="num2" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
+        <feature name="num3" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
+        <feature name="num7" mapto="RETRO_DEVICE_ID_JOYPAD_L3"/>
+        <feature name="num0" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
+        <feature name="star" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
+        <feature name="pound" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
+        <feature name="togglevkbd" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
     </controller>
     <controller id="game.controller.mouse" type="RETRO_DEVICE_MOUSE">
         <feature name="left" mapto="RETRO_DEVICE_ID_MOUSE_LEFT"/>

--- a/game.libretro.atari800/resources/buttonmap.xml
+++ b/game.libretro.atari800/resources/buttonmap.xml
@@ -21,10 +21,9 @@
     <controller id="game.controller.mouse" type="RETRO_DEVICE_MOUSE">
         <feature name="left" mapto="RETRO_DEVICE_ID_MOUSE_LEFT"/>
         <feature name="right" mapto="RETRO_DEVICE_ID_MOUSE_RIGHT"/>
-        <feature name="button4" mapto="RETRO_DEVICE_ID_MOUSE_X"/>
-        <feature name="button5" mapto="RETRO_DEVICE_ID_MOUSE_Y"/>
         <feature name="wheelup" mapto="RETRO_DEVICE_ID_MOUSE_WHEELUP"/>
         <feature name="wheeldown" mapto="RETRO_DEVICE_ID_MOUSE_WHEELDOWN"/>
+        <feature name="pointer" mapto="RETRO_DEVICE_MOUSE"/>
     </controller>
     <controller id="game.controller.keyboard" type="RETRO_DEVICE_KEYBOARD" subclass="0">
         <feature name="0" mapto="RETROK_0"/>

--- a/game.libretro.atari800/resources/topology.xml
+++ b/game.libretro.atari800/resources/topology.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <logicaltopology>
   <port type="keyboard">
     <accepts controller="game.controller.keyboard"/>
@@ -7,15 +7,19 @@
     <accepts controller="game.controller.mouse"/>
   </port>
   <port type="controller" id="1">
-    <accepts controller="game.controller.default"/>
+    <accepts controller="game.controller.atari.800"/>
+    <accepts controller="game.controller.atari.5200"/>
   </port>
   <port type="controller" id="2">
-    <accepts controller="game.controller.default"/>
+    <accepts controller="game.controller.atari.800"/>
+    <accepts controller="game.controller.atari.5200"/>
   </port>
   <port type="controller" id="3">
-    <accepts controller="game.controller.default"/>
+    <accepts controller="game.controller.atari.800"/>
+    <accepts controller="game.controller.atari.5200"/>
   </port>
   <port type="controller" id="4">
-    <accepts controller="game.controller.default"/>
+    <accepts controller="game.controller.atari.800"/>
+    <accepts controller="game.controller.atari.5200"/>
   </port>  
 </logicaltopology>


### PR DESCRIPTION
## Description

This PR updates the buttonmap and topology (added in https://github.com/kodi-game/game.libretro.atari800/pull/5) to use the Atari 2600 and Atari 5200 controllers of the original console.

I also added an Atari 800 controller and updated the Atari 5200 controller in https://github.com/kodi-game/controller-topology-project/pull/292:

* For the Atari 800 controller, I copied the Atari 2600 controller and modified the layout to reflect the buttonmap expected by atari800.
* For the Atari 5200 controller, I updated the layout to the buttonmap expected by atari800

Data comes from sources:

* https://github.com/libretro/libretro-atari800/blob/master/libretro/core-mapper.c
* https://github.com/libretro/libretro-atari800/blob/master/libretro/libretro-core.c
* https://github.com/libretro/libretro-atari800/blob/master/libretro/platform.c

## How has this been tested?

Testing in progress.